### PR TITLE
adds a simple Feign Client interface in the default Spring Boot Application Class location including a default service-consuming method and Circuit Breaker fallback method

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -80,3 +80,21 @@ generator:
     - "root_package": "com.opencredo.sandbox.rest"
     - "service_class_name": "RestSandbox"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker"
+  group: "atomist-rugs"
+  artifact: "spring-cloud-editors"
+  version: "0.2.0"
+  origin:
+    repo: "atomist-rugs/spring-cloud-editors.git"
+    branch: "b263095528641f17324548f57898c24dd0171b50"
+    sha: "b263095"
+  parameters:
+    - "consumed_endpoint_address": "http://external.service.org"
+    - "feign_interface": "FeignedExternalService"
+    - "invoking_relative_endpoint_url": "/myendpoint"
+    - "endpoint_invoking_method": "doTheThing"
+

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+		<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-feign</artifactId>
+        </dependency>
+    	<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-hystrix</artifactId>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>
@@ -68,4 +76,14 @@
 		</plugins>
 	</build>
 
+	<dependencyManagement>
+        <dependencies>	<dependency>
+              <groupId>org.springframework.cloud</groupId>
+              <artifactId>spring-cloud-dependencies</artifactId>
+              <version>Camden.RELEASE</version>
+              <type>pom</type>
+              <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/src/main/java/com/opencredo/sandbox/rest/FeignedExternalService.java
+++ b/src/main/java/com/opencredo/sandbox/rest/FeignedExternalService.java
@@ -1,0 +1,19 @@
+package com.opencredo.sandbox.rest;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@FeignClient(name = "http://external.service.org", fallback = FeignedExternalServiceFallback.class)
+interface FeignedExternalService {
+    @RequestMapping(value = "/myendpoint", method = GET)
+    String doTheThing();
+}
+
+class FeignedExternalServiceFallback implements FeignedExternalService {
+    @Override
+    public String doTheThing() {
+        return null;
+    }
+}

--- a/src/main/java/com/opencredo/sandbox/rest/RestSandboxApplication.java
+++ b/src/main/java/com/opencredo/sandbox/rest/RestSandboxApplication.java
@@ -2,8 +2,12 @@ package com.opencredo.sandbox.rest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableCircuitBreaker
 public class RestSandboxApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Created by Atomist Editor `atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker"
  group: "atomist-rugs"
  artifact: "spring-cloud-editors"
  version: "0.2.0"
  origin:
    repo: "atomist-rugs/spring-cloud-editors.git"
    branch: "b263095528641f17324548f57898c24dd0171b50"
    sha: "b263095"
  parameters:
    - "consumed_endpoint_address": "http://external.service.org"
    - "feign_interface": "FeignedExternalService"
    - "invoking_relative_endpoint_url": "/myendpoint"
    - "endpoint_invoking_method": "doTheThing"

```