### PR TITLE
adds a simple Feign Client interface in the default Spring Boot Application Class location including a default service-consuming method and Circuit Breaker fallback method

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -98,3 +98,21 @@ editor:
     - "invoking_relative_endpoint_url": "/myendpoint"
     - "endpoint_invoking_method": "doTheThing"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker"
+  group: "atomist-rugs"
+  artifact: "spring-cloud-editors"
+  version: "0.2.0"
+  origin:
+    repo: "atomist-rugs/spring-cloud-editors.git"
+    branch: "b263095528641f17324548f57898c24dd0171b50"
+    sha: "b263095"
+  parameters:
+    - "consumed_endpoint_address": "http://another.external.endpoint.com"
+    - "feign_interface": "FeignedExternalService"
+    - "invoking_relative_endpoint_url": "/myOtherEndpoint"
+    - "endpoint_invoking_method": "doTheOtherThing"
+

--- a/src/main/java/com/opencredo/sandbox/rest/FeignedExternalService.java
+++ b/src/main/java/com/opencredo/sandbox/rest/FeignedExternalService.java
@@ -5,15 +5,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
-@FeignClient(name = "http://external.service.org", fallback = FeignedExternalServiceFallback.class)
+@FeignClient(name = "http://another.external.endpoint.com", fallback = FeignedExternalServiceFallback.class)
 interface FeignedExternalService {
-    @RequestMapping(value = "/myendpoint", method = GET)
-    String doTheThing();
+    @RequestMapping(value = "/myOtherEndpoint", method = GET)
+    String doTheOtherThing();
 }
 
 class FeignedExternalServiceFallback implements FeignedExternalService {
     @Override
-    public String doTheThing() {
+    public String doTheOtherThing() {
         return null;
     }
 }


### PR DESCRIPTION
Created by Atomist Editor `atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "atomist-rugs.spring-cloud-editors.AddFeignClientWithCircuitBreaker"
  group: "atomist-rugs"
  artifact: "spring-cloud-editors"
  version: "0.2.0"
  origin:
    repo: "atomist-rugs/spring-cloud-editors.git"
    branch: "b263095528641f17324548f57898c24dd0171b50"
    sha: "b263095"
  parameters:
    - "consumed_endpoint_address": "http://another.external.endpoint.com"
    - "feign_interface": "FeignedExternalService"
    - "invoking_relative_endpoint_url": "/myOtherEndpoint"
    - "endpoint_invoking_method": "doTheOtherThing"

```